### PR TITLE
Fix: deprecated qnorr-font-family in favour of qnorr-primary-font-family

### DIFF
--- a/scss/global/_g.document.scss
+++ b/scss/global/_g.document.scss
@@ -43,7 +43,7 @@ body{
 }
 
 body {
-  font-family: $system-font-family;
+  font-family: $qnorr-primary-font-family;
   font-size: px-to-rem($qnorr-base-font-size);
   line-height: strip-unit($qnorr-base-leading/$qnorr-base-font-size);
   font-weight: 400;

--- a/scss/global/_g.resets.scss
+++ b/scss/global/_g.resets.scss
@@ -105,7 +105,7 @@ hr{
 
 h1, h2, h3, h4, h5, h6,
 input, button {
- font-family: $qnorr-font-family;
+ font-family: $qnorr-primary-font-family;
 }
 
 

--- a/scss/settings/_s.text.scss
+++ b/scss/settings/_s.text.scss
@@ -11,9 +11,8 @@ $system-font-family: -apple-system, BlinkMacSystemFont,
 
 
 /// @type String
-$qnorr-font-family: $system-font-family !default;
-/// @type String
-$qnorr-primary-font-family: $qnorr-font-family !default; // [1];
+$qnorr-primary-font-family: $system-font-family !default; // [1];
+
 /// @type String
 $qnorr-monospace-font-family: Roboto Mono, Inconsolata, monospace !default;
 


### PR DESCRIPTION
- clarity always wins over verbosity
- replaced font declaration applied to body to be equal to primary
$qnorr-primary-font-familty
- fixes #23 